### PR TITLE
return NA instead of stop error

### DIFF
--- a/R/visualization.R
+++ b/R/visualization.R
@@ -150,7 +150,8 @@ netVisual <- function(object, signaling, signaling.name = NULL, color.use = NULL
 
 
   if (length(pairLR.name.use) == 0) {
-    stop(paste0('There is no significant communication of ', signaling.name))
+    warning(paste0('There is no significant communication of ', signaling.name))
+    return(NA)
   } else {
     pairLR <- pairLR[pairLR.name.use,]
   }
@@ -473,7 +474,8 @@ netVisual_aggregate <- function(object, signaling, signaling.name = NULL, color.
 
 
   if (length(pairLR.name.use) == 0) {
-    stop(paste0('There is no significant communication of ', signaling.name))
+    warning(paste0('There is no significant communication of ', signaling.name))
+    return(NA)
   } else {
     pairLR <- pairLR[pairLR.name.use,]
   }
@@ -626,7 +628,8 @@ netVisual_individual <- function(object, signaling, signaling.name = NULL, pairL
   }
 
   if (length(pairLR.name.use) == 0) {
-    stop(paste0('There is no significant communication of ', signaling.name))
+    warning(paste0('There is no significant communication of ', signaling.name))
+    return(NA)
   } else {
     pairLR <- pairLR[pairLR.name.use,]
   }
@@ -2051,7 +2054,8 @@ netVisual_chord_cell <- function(object, signaling = NULL, net = NULL, slot.name
     }
 
     if (length(pairLR.name.use) == 0) {
-      stop(paste0('There is no significant communication of ', signaling))
+      warning(paste0('There is no significant communication of ', signaling))
+      return(NA)
     } else {
       pairLR <- pairLR[pairLR.name.use,]
     }


### PR DESCRIPTION
When I use the netVisual_aggregate() and other plotting functions, if the number of interaction is zero, the statement `stop(paste0('There is no significant communication of ', signaling.name))` simply throws an error and stop the script. This is not convenient when using a for loop to draw many graphs on the same page. Some iterations in the for loop have a condition where there is indeed no interactions, however, some iterations have conditions where there are interactions. The iterations in the for loop should be all drawn, at least not stop the whole script running.

My submitted change is to convert the stop() command to the warning() command, and return an NA to exit the function gracefully, so the script can go to the next iteration in the for loop. Ideally, empty circle graph without any connection but only having dots should be drawn. However, I think this is a big feature request. I don't know how to do it. For now, let's just make the script running and draw the blank on the page.