### PR TITLE
changed plan("multiprocess") to plan("multisession") for the netClustering call

### DIFF
--- a/R/analysis.R
+++ b/R/analysis.R
@@ -706,7 +706,7 @@ netClustering <- function(object, slot.name = "netP", type = c("functional","str
       N <- nrow(data.use)
       kRange <- seq(2,min(N-1, 10),by = 1)
       if (do.parallel) {
-        future::plan("multiprocess", workers = nCores)
+        future::plan("multisession", workers = nCores)
         options(future.globals.maxSize = 1000 * 1024^2)
       }
       my.sapply <- ifelse(


### PR DESCRIPTION
Considering the [recent update of the future package](https://cran.r-project.org/web/packages/future/news/news.html) (see Version 1.32.0 from 2023-03-06), the plan("multiprocess") is not available anymore. This breaks the netClustering function call, see also #571. 

To resolve it, two potential solutions can be used:
1) To replace plan("multiprocess") with plan("multisession"), as recommended by the future package maintainers - this is changed in this pull request;
2) To switch to an argument do.parallel = FALSE in the netClustering function - which, however, can be suboptimal for HPC users.

Best wishes,
Oleksandr