### PR TITLE
adjusted line future to new multisession

### DIFF
--- a/R/analysis.R
+++ b/R/analysis.R
@@ -734,7 +734,7 @@ netClustering <- function(object, slot.name = "netP", type = c("functional","str
       N <- nrow(data.use)
       kRange <- seq(2,min(N-1, 10),by = 1)
       if (do.parallel) {
-        future::plan("multiprocess", workers = nCores)
+        future::multisession(workers = nCores)
         options(future.globals.maxSize = 1000 * 1024^2)
       }
       my.sapply <- ifelse(


### PR DESCRIPTION
Dear Suoqin Jin,

future::plan(multiprocess) triggers a deprecated error when running netClustering function. The multiprocess alias is deprecated in the latest versions of future. See https://github.com/HenrikBengtsson/future/issues/420 for further information. 