### PR TITLE
New aggregateNet of no-significant-pathway for netVisual_diffInteraction

### DIFF
--- a/R/modeling.R
+++ b/R/modeling.R
@@ -327,6 +327,7 @@ computeCommunProbPathway <- function(object = NULL, net = NULL, pairLR.use = NUL
 #' @param remove.isolate whether removing the isolate cell groups without any interactions when applying \code{\link{subsetCommunication}}
 #' @param thresh threshold of the p-value for determining significant interaction
 #' @param return.object whether return an updated CellChat object
+#' @param non.significant.pathway wheter the pathway to be aggregated was detected as not overrepresented (with no significant interaction) in group. Default is NULL, set to TRUE when intending to use \code{\link{netVisual_diffInteraction}} for comparing a not overrepresented pathway in group. 
 #' @importFrom  dplyr group_by summarize groups
 #' @importFrom stringr str_split
 #'
@@ -340,7 +341,7 @@ computeCommunProbPathway <- function(object = NULL, net = NULL, pairLR.use = NUL
 #'
 #' @export
 #'
-aggregateNet <- function(object, sources.use = NULL, targets.use = NULL, signaling = NULL, pairLR.use = NULL, remove.isolate = TRUE, thresh = 0.05, return.object = TRUE) {
+aggregateNet <- function(object, sources.use = NULL, targets.use = NULL, signaling = NULL, pairLR.use = NULL, remove.isolate = TRUE, thresh = 0.05, return.object = TRUE, non.significant.pathway = NULL) {
   net <- object@net
   if (is.null(sources.use) & is.null(targets.use) & is.null(signaling) & is.null(pairLR.use)) {
     prob <- net$prob
@@ -356,10 +357,11 @@ aggregateNet <- function(object, sources.use = NULL, targets.use = NULL, signali
                                   sources.use = sources.use, targets.use = targets.use,
                                   signaling = signaling,
                                   pairLR.use = pairLR.use,
-                                  thresh = thresh)
+                                  thresh = thresh,
+                                  non.significant.pathway = non.significant.pathway)
     df.net$source_target <- paste(df.net$source, df.net$target, sep = "_")
-    df.net2 <- df.net %>% group_by(source_target) %>% summarize(count = n(), .groups = 'drop')
-    df.net3 <- df.net %>% group_by(source_target) %>% summarize(prob = sum(prob), .groups = 'drop')
+    df.net2 <- df.net %>% group_by(source_target) %>% dplyr::summarize(count = n(), .groups = 'drop')
+    df.net3 <- df.net %>% group_by(source_target) %>% dplyr::summarize(prob = sum(prob), .groups = 'drop')
     df.net2$prob <- df.net3$prob
     a <- stringr::str_split(df.net2$source_target, "_", simplify = T)
     df.net2$source <- as.character(a[, 1])


### PR DESCRIPTION
Dear Suoqin Jin,

When using aggregateNet() followed by netVisual_diffInteraction() for visualizing changes in cell-cell communication between two groups, it is possible only for pathways detected as overrepresented (with significant interaction) in both groups. Unfortunately, this is not always the case. In our research projects, we regularly find overrepresented pathways in only one of the disease conditions. In such cases, we still want to visualize and show the dimension of such differences. 

I have introduced some slight modifications in three of your functions (aggregateNet, subsetCommunication,  and subsetCommunication_internal) to calculate the aggregated network of nonsignificant pathways so they can be compared across groups. I created an example using your nonlesional (NL) and lesional (LS) data set for the TNF pathway, only detected as significant in the LS group (see zipped jupyter notebook in attachment, those lines changed are marked with #ADDED...). 

It would be great if you could provide me feedback on such an approach, and if you are convinced, merge the changes included in the pull requests, so the community could also explore such functionality. 

Best regards, 

Alvaro 
PS: I also added dplyr::summarize() in aggregateNet(). This solves an error when **plyr** is loaded after **dplyr**. 

[TEST_new_aggregateNet_netVisual_diffInteraction.zip](https://github.com/sqjin/CellChat/files/12549784/TEST_new_aggregateNet_netVisual_diffInteraction.zip)
