### PR TITLE
Use unique heatmap name, and other feature updates

### DIFF
--- a/R/visualization.R
+++ b/R/visualization.R
@@ -1776,8 +1776,9 @@ netVisual_diffInteraction <- function(object, comparison = c(1,2), measure = c("
 #' @param color.use the character vector defining the color of each cell group
 #' @param color.heatmap A vector of two colors corresponding to max/min values, or a color name in brewer.pal only when the data in the heatmap do not contain negative values
 #' @param title.name the name of the title
-#' @param width width of heatmap
-#' @param height height of heatmap
+#' @param legend.title the title of the heatmap legend
+#' @param width width of the heatmap bidy, should be a fixed `unit` object
+#' @param height height of the heatmap body, should be a fixed `unit` object
 #' @param font.size fontsize in heatmap
 #' @param font.size.title font size of the title
 #' @param cluster.rows whether cluster rows
@@ -1792,9 +1793,11 @@ netVisual_diffInteraction <- function(object, comparison = c(1,2), measure = c("
 #' @importFrom ComplexHeatmap Heatmap HeatmapAnnotation anno_barplot rowAnnotation
 #' @return  an object of ComplexHeatmap
 #' @export
-netVisual_heatmap <- function(object, comparison = c(1,2), measure = c("count", "weight"), signaling = NULL, slot.name = c("netP", "net"), color.use = NULL, color.heatmap = c("#2166ac","#b2182b"),
-                              title.name = NULL, width = NULL, height = NULL, font.size = 8, font.size.title = 10, cluster.rows = FALSE, cluster.cols = FALSE,
-                              sources.use = NULL, targets.use = NULL, remove.isolate = FALSE, row.show = NULL, col.show = NULL){
+netVisual_heatmap <- function(object, comparison = c(1,2), measure = c("count", "weight"), signaling = NULL,
+                              slot.name = c("netP", "net"), color.use = NULL, color.heatmap = c("#2166ac","#b2182b"),
+                              title.name = NULL, legend.title = NULL, width = NULL, height = NULL, font.size = 8, font.size.title = 10,
+                              cluster.rows = FALSE, cluster.cols = FALSE, sources.use = NULL, targets.use = NULL,
+                              remove.isolate = FALSE, row.show = NULL, col.show = NULL){
   # obj1 <- object.list[[comparison[1]]]
   # obj2 <- object.list[[comparison[2]]]
   if (!is.null(measure)) {
@@ -1816,7 +1819,7 @@ netVisual_heatmap <- function(object, comparison = c(1,2), measure = c("count", 
         title.name = "Differential interaction strength"
       }
     }
-    legend.name = "Relative values"
+    if(is.null(legend.title)) legend.title <- "Relative values"
   } else {
     message("Do heatmap based on a single object \n")
     if (!is.null(signaling)) {
@@ -1824,7 +1827,7 @@ netVisual_heatmap <- function(object, comparison = c(1,2), measure = c("count", 
       if (is.null(title.name)) {
         title.name = paste0(signaling, " signaling network")
       }
-      legend.name <- "Communication Prob."
+      if(is.null(legend.title)) legend.title <- "Communication Prob."
     } else if (!is.null(measure)) {
       net.diff <- object@net[[measure]]
       if (measure == "count") {
@@ -1836,7 +1839,7 @@ netVisual_heatmap <- function(object, comparison = c(1,2), measure = c("count", 
           title.name = "Interaction strength"
         }
       }
-      legend.name <- title.name
+      if(is.null(legend.title)) legend.title <- title.name
     }
   }
 
@@ -1916,24 +1919,31 @@ netVisual_heatmap <- function(object, comparison = c(1,2), measure = c("count", 
                                       show_legend = FALSE, show_annotation_name = FALSE,
                                       simple_anno_size = grid::unit(0.2, "cm"))
 
-  ha1 = rowAnnotation(Strength = anno_barplot(rowSums(abs(mat)), border = FALSE,gp = gpar(fill = color.use, col=color.use)), show_annotation_name = FALSE)
-  ha2 = HeatmapAnnotation(Strength = anno_barplot(colSums(abs(mat)), border = FALSE,gp = gpar(fill = color.use, col=color.use)), show_annotation_name = FALSE)
+  ha1 = rowAnnotation(Strength = anno_barplot(rowSums(abs(mat)), border = FALSE, gp = gpar(fill = color.use, col=color.use)), 
+ 		      show_annotation_name = FALSE)
+  ha2 = HeatmapAnnotation(Strength = anno_barplot(colSums(abs(mat)), border = FALSE,gp = gpar(fill = color.use, col=color.use)), 
+ 			  show_annotation_name = FALSE)
 
   if (sum(abs(mat) > 0) == 1) {
     color.heatmap.use = c("white", color.heatmap.use)
   } else {
     mat[mat == 0] <- NA
   }
-  ht1 = Heatmap(mat, col = color.heatmap.use, na_col = "white", name = legend.name,
+
+  ht.name <- paste0(abbreviate(legend.title), sample(.Machine$integer.max, 1))
+
+  ht1 = Heatmap(mat, col = color.heatmap.use, na_col = "white", name = ht.name,
                 bottom_annotation = col_annotation, left_annotation =row_annotation, top_annotation = ha2, right_annotation = ha1,
-                cluster_rows = cluster.rows,cluster_columns = cluster.rows,
-                row_names_side = "left",row_names_rot = 0,row_names_gp = gpar(fontsize = font.size),column_names_gp = gpar(fontsize = font.size),
-               # width = unit(width, "cm"), height = unit(height, "cm"),
-                column_title = title.name,column_title_gp = gpar(fontsize = font.size.title),column_names_rot = 90,
-                row_title = "Sources (Sender)",row_title_gp = gpar(fontsize = font.size.title),row_title_rot = 90,
-                heatmap_legend_param = list(title_gp = gpar(fontsize = 8, fontface = "plain"),title_position = "leftcenter-rot",
-                                            border = NA, #at = colorbar.break,
-                                            legend_height = unit(20, "mm"),labels_gp = gpar(fontsize = 8),grid_width = unit(2, "mm"))
+                cluster_rows = cluster.rows, cluster_columns = cluster.rows,
+                row_names_side = "left", row_names_rot = 0, column_names_rot = 90, row_title_rot = 90,  
+                row_names_gp = gpar(fontsize = font.size), column_names_gp = gpar(fontsize = font.size),
+                row_title = "Sources (Sender)", row_title_gp = gpar(fontsize = font.size.title),
+                column_title = title.name, column_title_gp = gpar(fontsize = font.size.title),
+                width = width, height = height,
+                heatmap_legend_param = list(title = legend.title, title_gp = gpar(fontsize = font.size, fontface = "plain"),  
+                                            title_position = "leftcenter-rot", border = NA, #at = colorbar.break,
+                                            legend_height = unit(20, "mm"), labels_gp = gpar(fontsize = font.size),  
+                                            grid_width = unit(2, "mm"))
   )
   #  draw(ht1)
   return(ht1)


### PR DESCRIPTION
This PR (1) resolve the issue with duplicated `Heatmap` object name when joining 2 or more `Heatmap` objects created by the `netVisual_heatmap` function, by create a unique `ht.name` name and assed to the `Heatmap` function.

When creating a heatmap list in the later version of `ComplexHeatmap`, each `Heatmap` object should have a unique name, if not, a warning message such as `Heatmap/annotation names are duplicated` is produced (as noted in #170). When used in Jupyter Notebook, this issue resulted in an error message provided below.

This PR (2) adds the ability for users to assign legend title to each heatmap using `legend.title`. This is useful when creating plots showing heatmap side-by-side to compare number/strength of interactions from multiple datasets, with legend named specifically for each dataset. 

This PR(3) re-introduce the paramater for users to change the `width` and `height` of the heatmap body.

Minor changes are to standardise the font size of the legend title and label from `fontsize = 8` to use `font.size` which default to `8`.

```r
ERROR while rich displaying an object: Error in grid.Call.graphics(C_downvppath, name$path, name$name, strict): Viewport 'Relative values_heatmap_body_1_1' was not found

Traceback:
1. tryCatch(withCallingHandlers({
 .     if (!mime %in% names(repr::mime2repr)) 
 .         stop("No repr_* for mimetype ", mime, " in repr::mime2repr")
 .     rpr <- repr::mime2repr[[mime]](obj)
 .     if (is.null(rpr)) 
 .         return(NULL)
 .     prepare_content(is.raw(rpr), rpr)
 . }, error = error_handler), error = outer_handler)
2. tryCatchList(expr, classes, parentenv, handlers)
3. tryCatchOne(expr, names, parentenv, handlers[[1L]])
4. doTryCatch(return(expr), name, parentenv, handler)
5. withCallingHandlers({
 .     if (!mime %in% names(repr::mime2repr)) 
 .         stop("No repr_* for mimetype ", mime, " in repr::mime2repr")
 .     rpr <- repr::mime2repr[[mime]](obj)
 .     if (is.null(rpr)) 
 .         return(NULL)
 .     prepare_content(is.raw(rpr), rpr)
 . }, error = error_handler)
6. repr::mime2repr[[mime]](obj)
7. repr_text.default(obj)
8. paste(capture.output(print(obj)), collapse = "\n")
9. capture.output(print(obj))
10. withVisible(...elt(i))
# --- below omitted ---
```