### PR TITLE
Use progressr with future framework for progress updates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ LazyData: true
 Imports:
     future,
     future.apply,
-    pbapply,
+    progressr,
     irlba,
     NMF (>= 0.23.0),
     ggalluvial,

--- a/R/analysis.R
+++ b/R/analysis.R
@@ -733,9 +733,16 @@ netClustering <- function(object, slot.name = "netP", type = c("functional","str
     } else {
       N <- nrow(data.use)
       kRange <- seq(2,min(N-1, 10),by = 1)
+      nCores <- as.integer(nCores)
       if (do.parallel) {
-        future::plan("multiprocess", workers = nCores)
+        if (.Platform$OS.type == "windows") {
+          future::plan("multisession", workers = nCores)
+	} else {
+          future::plan("multicore", workers = nCores)
+	}
         options(future.globals.maxSize = 1000 * 1024^2)
+      } else {
+        future::plan("sequential")
       }
       my.sapply <- ifelse(
         test = future::nbrOfWorkers() == 1,

--- a/R/analysis.R
+++ b/R/analysis.R
@@ -190,10 +190,9 @@ netAnalysis_contribution <- function(object, signaling, signaling.name = NULL, s
 #' @param net compute the centrality measures on a specific signaling network given by a 2 or 3 dimemsional array net
 #' @param net.name a character vector giving the name of signaling networks
 #' @param thresh threshold of the p-value for determining significant interaction
-#' @importFrom future nbrOfWorkers
 #' @importFrom methods slot
 #' @importFrom future.apply future_sapply
-#' @importFrom pbapply pbsapply
+#' @importFrom progressr progressor
 #'
 #' @return
 #' @export
@@ -211,17 +210,16 @@ netAnalysis_computeCentrality <- function(object = NULL, slot.name = "netP", net
   }
   if (length(dim(net)) == 3) {
     nrun <- dim(net)[3]
-    my.sapply <- ifelse(
-      test = future::nbrOfWorkers() == 1,
-      yes = pbapply::pbsapply,
-      no = future.apply::future_sapply
-    )
-    centr.all = my.sapply(
+    p <- progressr::progressor(nrun)
+    centr.all <- future.apply::future_sapply(
       X = 1:nrun,
       FUN = function(x) {
+	Sys.sleep(1/nrun)
+        p(sprintf("%g of %g", x, nrun)) # Use with_progress() to see progress bar in client-side
         net0 <- net[ , , x]
-        return(computeCentralityLocal(net0))
+	computeCentralityLocal(net0)
       },
+      future.seed = TRUE,
       simplify = FALSE
     )
   } else {
@@ -705,9 +703,9 @@ netEmbedding <- function(object, slot.name = "netP", type = c("functional","stru
 #' @param nCores number of workers when doing parallel
 #' @param k.eigen the number of eigenvalues used when doing spectral clustering
 #' @importFrom methods slot
-#' @importFrom future nbrOfWorkers plan
+#' @importFrom future plan
 #' @importFrom future.apply future_sapply
-#' @importFrom pbapply pbsapply
+#' @importFrom progressr progressor
 #' @return
 #' @export
 #'
@@ -733,6 +731,7 @@ netClustering <- function(object, slot.name = "netP", type = c("functional","str
     } else {
       N <- nrow(data.use)
       kRange <- seq(2,min(N-1, 10),by = 1)
+      kN <- length(kRange)
       nCores <- as.integer(nCores)
       if (do.parallel) {
         if (.Platform$OS.type == "windows") {
@@ -744,24 +743,23 @@ netClustering <- function(object, slot.name = "netP", type = c("functional","str
       } else {
         future::plan("sequential")
       }
-      my.sapply <- ifelse(
-        test = future::nbrOfWorkers() == 1,
-        yes = pbapply::pbsapply,
-        no = future.apply::future_sapply
-      )
-      results = my.sapply(
-        X = 1:length(kRange),
+      message(sprintf("future plan is '%s'", as.character(attr(future::plan(), "call"))[2]))
+      p <- progressr::progressor(kN)
+      results <- future.apply::future_sapply(
+        X = 1:kN,
         FUN = function(x) {
-          idents <- kmeans(data.use,kRange[x],nstart=10)$cluster
+          Sys.sleep(1/kN)
+          p(sprintf("%g of %g", x, kN)) # Use with_progress() to see progress bar in client-side
+          idents <- kmeans(data.use, kRange[x], nstart = 10)$cluster
           clusIndex <- idents
-          #adjMat0 <- as.numeric(outer(clusIndex, clusIndex, FUN = "==")) - outer(1:N, 1:N, "==")
           adjMat0 <- Matrix::Matrix(as.numeric(outer(clusIndex, clusIndex, FUN = "==")), nrow = N, ncol = N)
-          return(list(adjMat = adjMat0, ncluster = length(unique(idents))))
+          list(adjMat = adjMat0, ncluster = length(unique(idents)))
         },
+        future.seed = TRUE,
         simplify = FALSE
       )
       adjMat <- lapply(results, "[[", 1)
-      CM <- Reduce('+', adjMat)/length(kRange)
+      CM <- Reduce('+', adjMat)/kN
       res <- computeEigengap(as.matrix(CM))
       numCluster <- res$upper_bound
       clusters = kmeans(data.use,numCluster,nstart=10)$cluster


### PR DESCRIPTION
This PR changes how some functions deal with sequential and parallel processes. 

Following the suggestion in #424 and discussion in #140 regarding the missing `future.seed` setting, I dropped the detection of number of cores and the `ifelse` switch between `pbapply::pbsapply` and `future.apply::future_sapply` for sequential and parallel computing respectively, and opted to use the `progressr` package for progress updates. The package came installed with `CellChat`, so there is no need to install additional dependencies.

I also:
- Remove the deprecated future plan `multiprocess` in the `netClustering` function (similar PRs: #574 and #682) and replace it with either `multisession` or `multicore` depending on the detected OS type (`multicore` is significant faster than `multisession` in the Linux environment that I am using).
- Parallelise the calculation of `Pboot` (default with 100 permutations) in the `computeCommunProb` function, which was running sequentially before. The update should significantly speed up `computeCommunProb()`.